### PR TITLE
WS address fix

### DIFF
--- a/idex.go
+++ b/idex.go
@@ -9,7 +9,7 @@ type Idex struct {
 // IDEX rest and websocket urls
 const (
 	APIURL = "https://api.idex.market"
-	WSURL  = "wss://v1.idex.market"
+	WSURL  = "wss://wss.idex.market"
 )
 
 // New instance of an Idex


### PR DESCRIPTION
Seems Idex has changed their WS endpoint address, since the original one returns 403 error now.